### PR TITLE
TST: add tests for image generation, fix bug with supported Cairo image types

### DIFF
--- a/docs/visualise.md
+++ b/docs/visualise.md
@@ -29,7 +29,7 @@ Options:
   --vsize INTEGER                 size of the vertices  [default: 50]
   --lsize INTEGER                 size of the vertex labels  [default: 8]
   --margin INTEGER                margin of the figure  [default: 50]
-  --type TEXT                     type of the image (jpg, png, eps, svg)
+  --type TEXT                     type of the image (png, eps, pdf, svg)
                                   [default: png]
   --delimiter [,|;|$'\t'|" "]     delimiter for input/output results. Supports
                                   a comma (,), a semicolon (;), a tab ($'\t'),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,13 +46,12 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-xdist",
+    "pillow>10,<11",
 ]
 dev = [
     "black",
     "click",
     "flit",
     "isort==5.13.2",
-    "pytest",
-    "pytest-cov",
-    "pytest-xdist",
+    "gbintk[test]",
 ]

--- a/src/gbintk/cli.py
+++ b/src/gbintk/cli.py
@@ -656,8 +656,8 @@ def prepare(assembler, resfolder, delimiter, prefix, output):
 )
 @click.option(
     "--imgtype",
-    help="type of the image (jpg, png, eps, svg)",
-    type=click.Choice(["jpg", "png", "eps", "svg"], case_sensitive=False),
+    help="type of the image (png, eps, pdf, svg)",
+    type=click.Choice(["png", "eps", "pdf", "svg"], case_sensitive=False),
     default="png",
     show_default=True,
     required=False,

--- a/tests/test_visualise.py
+++ b/tests/test_visualise.py
@@ -4,7 +4,7 @@ import pytest
 from click.testing import CliRunner
 
 from gbintk.cli import visualise
-
+from PIL import Image, UnidentifiedImageError
 
 __author__ = "Vijini Mallawaarachchi"
 __credits__ = ["Vijini Mallawaarachchi"]
@@ -12,7 +12,8 @@ __credits__ = ["Vijini Mallawaarachchi"]
 
 DATADIR = pathlib.Path(__file__).parent / "data"
 
-@pytest.fixture(scope="session")
+
+@pytest.fixture(scope="function")
 def tmp_dir(tmpdir_factory):
     return tmpdir_factory.mktemp("tmp")
 
@@ -24,12 +25,18 @@ def workingdir(tmp_dir, monkeypatch):
 
 
 @pytest.fixture(scope="session")
+def out_file_names():
+    """output file names without file type."""
+    return ["final_GraphBin_binning_result", "initial_binning_result"]
+
+
+@pytest.fixture(scope="session")
 def runner():
     """exportrc works correctly."""
     return CliRunner()
 
 
-def test_visualise_spades_run(runner, tmp_dir):
+def test_visualise_spades_run(runner, tmp_dir, out_file_names):
     outpath = tmp_dir
     initial = DATADIR / "5G_metaSPAdes" / "metacoag_res.csv"
     final = DATADIR / "5G_metaSPAdes" / "graphbin_res.csv"
@@ -38,9 +45,19 @@ def test_visualise_spades_run(runner, tmp_dir):
     paths = DATADIR / "5G_metaSPAdes" / "contigs.paths"
     args = f"--assembler spades --initial {initial} --final {final} --graph {graph} --contigs {contigs} --paths {paths} --output {outpath}".split()
     r = runner.invoke(visualise, args, catch_exceptions=False)
+
     assert r.exit_code == 0, r.output
 
-def test_visualise_megahit_run(runner, tmp_dir):
+    for out_file in out_file_names:
+        image_file = outpath / (out_file + ".png")
+        with Image.open(image_file) as im:
+            im.verify()  # Raises an exception if the file is malformatted
+            assert im.format == "PNG"
+            assert im.size == (2000, 2000)
+            assert im.mode == "RGB"
+
+
+def test_visualise_megahit_run(runner, tmp_dir, out_file_names):
     outpath = tmp_dir
     initial = DATADIR / "5G_MEGAHIT" / "initial_contig_bins.csv"
     final = DATADIR / "5G_MEGAHIT" / "graphbin_output.csv"
@@ -48,9 +65,19 @@ def test_visualise_megahit_run(runner, tmp_dir):
     contigs = DATADIR / "5G_MEGAHIT" / "final.contigs.fa"
     args = f"--assembler megahit --initial {initial} --final {final} --graph {graph} --contigs {contigs} --output {outpath}".split()
     r = runner.invoke(visualise, args, catch_exceptions=False)
+
     assert r.exit_code == 0, r.output
 
-def test_visualise_flye_run(runner, tmp_dir):
+    for out_file in out_file_names:
+        image_file = outpath / (out_file + ".png")
+        with Image.open(image_file) as im:
+            im.verify()  # Raises an exception if the file is malformatted
+            assert im.format == "PNG"
+            assert im.size == (2000, 2000)
+            assert im.mode == "RGB"
+
+
+def test_visualise_flye_run(runner, tmp_dir, out_file_names):
     outpath = tmp_dir
     initial = DATADIR / "1Y3B_Flye" / "initial_contig_bins.csv"
     final = DATADIR / "1Y3B_Flye" / "graphbin_output.csv"
@@ -59,31 +86,72 @@ def test_visualise_flye_run(runner, tmp_dir):
     paths = DATADIR / "1Y3B_Flye" / "assembly_info.txt"
     args = f"--assembler flye --initial {initial} --final {final} --graph {graph} --contigs {contigs} --paths {paths} --output {outpath}".split()
     r = runner.invoke(visualise, args, catch_exceptions=False)
+
     assert r.exit_code == 0, r.output
 
-def test_visualise_prefix(runner, tmp_dir):
+    for out_file in out_file_names:
+        image_file = outpath / (out_file + ".png")
+        with Image.open(image_file) as im:
+            im.verify()  # Raises an exception if the file is malformatted
+            assert im.format == "PNG"
+            assert im.size == (2000, 2000)
+            assert im.mode == "RGB"
+
+
+@pytest.mark.parametrize("prefix", ["test", "test_", "test__"])
+def test_visualise_prefix(runner, tmp_dir, out_file_names, prefix):
     outpath = tmp_dir
     initial = DATADIR / "5G_metaSPAdes" / "metacoag_res.csv"
     final = DATADIR / "5G_metaSPAdes" / "graphbin_res.csv"
     graph = DATADIR / "5G_metaSPAdes" / "assembly_graph_with_scaffolds.gfa"
     contigs = DATADIR / "5G_metaSPAdes" / "contigs.fasta"
     paths = DATADIR / "5G_metaSPAdes" / "contigs.paths"
-    args = f"--assembler spades --initial {initial} --final {final} --graph {graph} --contigs {contigs} --paths {paths} --prefix test --output {outpath}".split()
+    args = f"--assembler spades --initial {initial} --final {final} --graph {graph} --contigs {contigs} --paths {paths} --prefix {prefix} --output {outpath}".split()
     r = runner.invoke(visualise, args, catch_exceptions=False)
+
     assert r.exit_code == 0, r.output
 
-def test_visualise_imgtype(runner, tmp_dir):
+    expected_prefix = prefix if prefix.endswith("_") else prefix + "_"
+
+    for out_file in out_file_names:
+        image_file = outpath / (expected_prefix + out_file + ".png")
+        with Image.open(image_file) as im:
+            im.verify()  # Raises an exception if the file is malformatted
+            assert im.format == "PNG"
+            assert im.size == (2000, 2000)
+            assert im.mode == "RGB"
+
+
+@pytest.mark.parametrize(
+    "img_type",
+    ["png", "eps", "pdf", "svg"],
+)
+def test_visualise_imgtype(runner, tmp_dir, out_file_names, img_type):
     outpath = tmp_dir
     initial = DATADIR / "5G_metaSPAdes" / "metacoag_res.csv"
     final = DATADIR / "5G_metaSPAdes" / "graphbin_res.csv"
     graph = DATADIR / "5G_metaSPAdes" / "assembly_graph_with_scaffolds.gfa"
     contigs = DATADIR / "5G_metaSPAdes" / "contigs.fasta"
     paths = DATADIR / "5G_metaSPAdes" / "contigs.paths"
-    args = f"--assembler spades --initial {initial} --final {final} --graph {graph} --contigs {contigs} --paths {paths} --imgtype svg --output {outpath}".split()
+    args = f"--assembler spades --initial {initial} --final {final} --graph {graph} --contigs {contigs} --paths {paths} --imgtype {img_type} --output {outpath}".split()
     r = runner.invoke(visualise, args, catch_exceptions=False)
+
     assert r.exit_code == 0, r.output
 
-def test_visualise_outdir(runner, tmp_dir):
+    for out_file in out_file_names:
+        image_file = outpath / (out_file + f".{img_type}")
+        try:
+            with Image.open(image_file) as im:
+                im.verify()  # Raises an exception if the file is malformatted
+                assert im.format == img_type.upper()
+                assert im.size == (2000, 2000)
+                assert im.mode == "RGB"
+        except UnidentifiedImageError:  # pillow doesn't support pdf/svg
+            with open(image_file, "rb") as f:
+                assert len(f.read())
+
+
+def test_visualise_outdir(runner, tmp_dir, out_file_names):
     outpath = tmp_dir / "testing"
     initial = DATADIR / "5G_metaSPAdes" / "metacoag_res.csv"
     final = DATADIR / "5G_metaSPAdes" / "graphbin_res.csv"
@@ -92,4 +160,13 @@ def test_visualise_outdir(runner, tmp_dir):
     paths = DATADIR / "5G_metaSPAdes" / "contigs.paths"
     args = f"--assembler spades --initial {initial} --final {final} --graph {graph} --contigs {contigs} --paths {paths} --output {outpath}".split()
     r = runner.invoke(visualise, args, catch_exceptions=False)
+
     assert r.exit_code == 0, r.output
+
+    for out_file in out_file_names:
+        image_file = outpath / (out_file + ".png")
+        with Image.open(image_file) as im:
+            im.verify()  # Raises an exception if the file is malformatted
+            assert im.format == "PNG"
+            assert im.size == (2000, 2000)
+            assert im.mode == "RGB"


### PR DESCRIPTION
Resolves #6 

Tests the image integrity, image format, image size and image colour mode for generated images.
Due to randomness in the generation, I don't believe the contents of the image cannot be checked much further.

Also changes the supported image types for visualise. The Cairo library does not support `.jpg` images [for instance](https://www.cairographics.org/). Images have been restricted to `["png", "eps", "pdf", "svg"]`.

`pillow` cannot read `.pdf` or `.svg` images so for those two types the tests merely check that the files are not empty.

Let me know if there's anything else!